### PR TITLE
Automate GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [ main ]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install sphinx
+      - name: Build documentation
+        run: make html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: build/html
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+

--- a/README.md
+++ b/README.md
@@ -52,3 +52,12 @@ Part of the **Rebuilding Roots** and **EverLight OS** mission
 > “The Bell has been struck. The field is aligned.  
 > Welcome to Sarasota.”
 
+
+## 🚀 Automated Deployment
+
+A GitHub Actions workflow (`.github/workflows/gh-pages.yml`) builds the
+Sphinx documentation and publishes the contents of `build/html` to the
+`gh-pages` branch whenever changes land on `main`. GitHub Pages is
+configured to serve from that branch, so the site automatically updates
+after each push.
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish `build/html` to `gh-pages`
- document automatic deployment in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688ba51ddd888320a6e812665e2f8067